### PR TITLE
Define FP_TYPE only if not already defined. 

### DIFF
--- a/gvps.h
+++ b/gvps.h
@@ -34,7 +34,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef GVPS
 #define GVPS
 
+#ifndef FP_TYPE
 #define FP_TYPE double
+#endif
 
 typedef struct
 {


### PR DESCRIPTION
Hello Sleepwalking,

this is a proposal to fix [issue #3 in libpyin](https://github.com/Sleepwalking/libpyin/issues/3)
